### PR TITLE
Fixed path separator in crop_videos.py

### DIFF
--- a/utils/crop_videos.py
+++ b/utils/crop_videos.py
@@ -26,7 +26,8 @@ args = vars(parser.parse_args())
 
 def extract_vid_uuid(vid_path: str) -> str:
     """Extracts uuid from video path"""
-    vid_name = vid_path.split("\\")[-1]
+    vid_path = vid_path.replace("\\","/")
+    vid_name = vid_path.split("/")[-1]
     uuid = vid_name.split(".")[0]
     return uuid
 

--- a/utils/crop_videos.py
+++ b/utils/crop_videos.py
@@ -2,8 +2,8 @@
 Takes a given video and outputs cropped frames of the video.
 """
 import argparse
+import pathlib
 from utils.default_video_cropper import DefaultVideoCropper
-
 
 parser = argparse.ArgumentParser(
     description="Crop a video and store frames locally", add_help=False
@@ -26,9 +26,8 @@ args = vars(parser.parse_args())
 
 def extract_vid_uuid(vid_path: str) -> str:
     """Extracts uuid from video path"""
-    vid_path = vid_path.replace("\\","/")
-    vid_name = vid_path.split("/")[-1]
-    uuid = vid_name.split(".")[0]
+    vid_path = pathlib.Path(vid_path)
+    uuid = vid_path.with_suffix("").name  # Remove file extension (.mp4,.webm)
     return uuid
 
 


### PR DESCRIPTION
Since you can use forward & backward slashes in file paths, and the code only accounted for backslashes, backslashes now get converted to normal slashes.
When videos had / in their path name, it broke the extract_uuid function, therefore wanting to create a new subdir to write images to, which didn't work.
I did test it, cropping and turning it into images works now